### PR TITLE
fix for the Link issue

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -36,6 +36,7 @@ module.exports = {
         name: 'images',
       },
     },
+    "gatsby-transformer-javascript-frontmatter",
     `gatsby-transformer-remark`,
     {
       resolve:'gatsby-plugin-purgecss', // purges all unused/unreferenced css rules

--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
   "version": "0.1.5",
   "author": "Walter Perdan <info@kalwaltart.it> (www.kalwaltart.it)",
   "dependencies": {
+    "@babel/parser": "^7.3.4",
+    "@babel/traverse": "^7.3.4",
     "@fortawesome/fontawesome-svg-core": "^1.2.15",
     "@fortawesome/free-brands-svg-icons": "^5.7.2",
     "@fortawesome/free-solid-svg-icons": "^5.7.2",
@@ -28,6 +30,7 @@
     "gatsby-plugin-typography": "^2.2.0",
     "gatsby-remark-relative-images": "^0.2.2",
     "gatsby-source-filesystem": "^2.0.23",
+    "gatsby-transformer-javascript-frontmatter": "^2.0.9",
     "gatsby-transformer-remark": "^2.1.1",
     "intl": "^1.2.5",
     "lodash": "^4.17.10",

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -24,9 +24,9 @@ const Footer = class extends React.Component {
                 <div className="column is-4">
                 <section className="menu">
                     <ul className="menu-list">
-                      <li><Link to={props.langKey} className="navbar-item">Home</Link></li>
-                      <li><Link className="navbar-item" to={props.langKey + "/" + menuTree.about[sel] +"/"}>About</Link></li>
-                      <li><Link className="navbar-item" to={props.langKey + "/" + menuTree.artworks[sel] +"/"}>
+                      <li><Link to={"/" + props.langKey} className="navbar-item">Home</Link></li>
+                      <li><Link className="navbar-item" to={"/" + props.langKey + "/" + menuTree.about[sel] +"/"}>About</Link></li>
+                      <li><Link className="navbar-item" to={"/" + props.langKey + "/" + menuTree.artworks[sel] +"/"}>
                         Artworks
                       </Link>
                     </li>
@@ -45,12 +45,12 @@ const Footer = class extends React.Component {
                 <section>
                   <ul className="menu-list">
                   <li>
-                    <Link className="navbar-item" to={props.langKey + "/" + menuTree.blog[sel] +"/"}>
+                    <Link className="navbar-item" to={"/" + props.langKey + "/" + menuTree.blog[sel] +"/"}>
                       Latest Stories
                     </Link>
                   </li>
                   <li>
-                    <Link className="navbar-item" to={props.langKey + "/" + menuTree.contact[sel] +"/"}>
+                    <Link className="navbar-item" to={"/" + props.langKey + "/" + menuTree.contact[sel] +"/"}>
                       Contact
                     </Link>
                   </li>

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import Link from 'gatsby-link'
+import { Link } from 'gatsby'
 import logo from '../img/logo.svg'
 import { FaHome, FaQuestion, FaImage, FaPenAlt, FaAmericanSignLanguageInterpreting } from 'react-icons/fa';
 import SelectLanguage from './SelectLanguage';
@@ -56,19 +56,19 @@ const Header = class extends React.Component {
         </div>
         <div id="navMenu" className="navbar-menu">
         <div className="navbar-start has-text-centered">
-          <Link className="navbar-item" to={props.langKey}>
+          <Link className="navbar-item" to={"/" + props.langKey}>
             <FaHome /> <FormattedMessage id="home" />
           </Link>
-          <Link className="navbar-item" to={props.langKey + "/" + menuTree.about[sel] +"/"}>
+          <Link className="navbar-item" to={"/" + props.langKey + "/" + menuTree.about[sel] +"/"}>
             <FaQuestion /> <FormattedMessage id="about" />
           </Link>
-          <Link className="navbar-item" to={props.langKey + "/" + menuTree.artworks[sel] +"/"}>
+          <Link className="navbar-item" to={"/" + props.langKey + "/" + menuTree.artworks[sel] +"/"}>
             <FaImage /> <FormattedMessage id="artworks" />
           </Link>
-          <Link className="navbar-item" to={props.langKey + "/" + menuTree.blog[sel] +"/"}>
+          <Link className="navbar-item" to={"/" + props.langKey + "/" + menuTree.blog[sel] +"/"}>
             <FaPenAlt /> <FormattedMessage id="blog" />
           </Link>
-          <Link className="navbar-item" to={props.langKey + "/" + menuTree.contact[sel] +"/"}>
+          <Link className="navbar-item" to={"/" + props.langKey + "/" + menuTree.contact[sel] +"/"}>
             <FaAmericanSignLanguageInterpreting /> <FormattedMessage id="contact" />
           </Link>
         </div>

--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react'
-import Link from "gatsby-link"
+//import Link from "gatsby-link"
 import { graphql } from 'gatsby'
 import PropTypes from 'prop-types'
 import Header from '../components/Header'
@@ -32,7 +32,7 @@ const getIdUrl = (id, langKey) => {
     case 'it':
     res = articleId[id][1];
     break;
-    default: return null;
+    default: return ' ';
   }
   return res;
 }

--- a/src/data/articleTree.js
+++ b/src/data/articleTree.js
@@ -1,9 +1,10 @@
 module.exports = {
   '1': ['/', '/'],
-  '2': ['about','presentazione'],
-  '3': ['contact','contatto'],
-  '4': ['artworks','opere'],
-  '5': ['artworks-page-test','pagina-opere-test'],
-  '6': ['2019-02-01-my-first-gatsby-blog-post','2019-02-01-mio-primo-blog-post-gatsby'],
-  '7': ['2019-03-11-news-from-art-planet', '2019-03-11-notizie-dal-pianeta-arte'],
+  '2': ['blog', 'blog'],
+  '3': ['about','presentazione'],
+  '4': ['contact','contatto'],
+  '5': ['artworks','opere'],
+  '6': ['artworks-page-test','pagina-opere-test'],
+  '7': ['2019-02-01-my-first-gatsby-blog-post','2019-02-01-mio-primo-blog-post-gatsby'],
+  '8': ['2019-03-11-news-from-art-planet', '2019-03-11-notizie-dal-pianeta-arte'],
 };

--- a/src/pages/blog/index.en.js
+++ b/src/pages/blog/index.en.js
@@ -4,6 +4,11 @@ import Layout from '../../components/Layout'
 import BlogRoll from '../../components/BlogRoll_en'
 import { graphql } from 'gatsby'
 
+export const frontmatter = {
+  id:  '02',
+  title: "blog page",
+}
+
 export default class BlogIndexPage extends React.Component {
 
   render() {
@@ -54,11 +59,22 @@ export const pageQuery = graphql`
         }
       }
     }
+    allJavascriptFrontmatter {
+    edges {
+      node {
+        frontmatter {
+          id
+          title
+        }
+      }
+    }
+  }
     markdownRemark
      {
       id
       html
       frontmatter {
+        id
         date
         title
         description

--- a/src/pages/blog/index.it.js
+++ b/src/pages/blog/index.it.js
@@ -4,6 +4,12 @@ import Layout from '../../components/Layout'
 import BlogRoll from '../../components/BlogRoll_it'
 import { graphql } from 'gatsby'
 
+export const frontmatter = {
+  id:  '02',
+  title: "pagina blog",
+}
+
+
 export default class BlogIndexPage extends React.Component {
 
   render() {
@@ -54,11 +60,22 @@ export const pageQuery = graphql`
         }
       }
     }
+    allJavascriptFrontmatter {
+    edges {
+      node {
+        frontmatter {
+          id
+          title
+        }
+      }
+    }
+  }
     markdownRemark
      {
       id
       html
       frontmatter {
+        id
         date
         title
         description

--- a/src/templates/home.js
+++ b/src/templates/home.js
@@ -60,6 +60,16 @@ export const pageQuery = graphql`
         }
       }
     }
+    allJavascriptFrontmatter {
+  edges {
+    node {
+      frontmatter {
+        id
+        title   
+      }
+    }
+  }
+}
     markdownRemark(id: {eq: $id}) {
       html
       frontmatter {

--- a/yarn.lock
+++ b/yarn.lock
@@ -738,14 +738,6 @@
     lodash "^4.17.11"
     to-fast-properties "^2.0.0"
 
-"@contentful/axios@^0.18.0":
-  version "0.18.0"
-  resolved "https://registry.yarnpkg.com/@contentful/axios/-/axios-0.18.0.tgz#576e0e6047411a66971e82d40688a8c795e62f27"
-  integrity sha512-4r4Ww1IJlmRolKgovLTTmdS6CsdvXYVxgXRFwWSh1x36T/0Wg9kTwdaVaApZXcv1DfYyw9RSNdxIGSwTP2/Lag==
-  dependencies:
-    follow-redirects "^1.2.5"
-    is-buffer "^1.1.5"
-
 "@fortawesome/fontawesome-common-types@^0.2.15":
   version "0.2.15"
   resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.15.tgz#16af950653083d1e3064061de9f8e5e3b579f688"
@@ -2486,32 +2478,6 @@ content-type@^1.0.4, content-type@~1.0.4:
   resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.4.tgz#e138cc75e040c727b1966fe5e5f8c9aee256fe3b"
   integrity sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==
 
-contentful-resolve-response@^1.1.4:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/contentful-resolve-response/-/contentful-resolve-response-1.1.4.tgz#9eb656876eecb2cd00444f0adf26bd91a5ec1992"
-  integrity sha512-oFq6n6zjbiwD9/7mBa8YHPwvPM0B0D4uOgg1n/rVzpQPhCrzeIixNj6fbJAbDiJt05rZqxiY3K1Db7pPRhRaZw==
-  dependencies:
-    lodash "^4.17.4"
-
-contentful-sdk-core@^6.0.0-beta0:
-  version "6.2.1"
-  resolved "https://registry.yarnpkg.com/contentful-sdk-core/-/contentful-sdk-core-6.2.1.tgz#1d190674ffa94e27a0c12e05a6d7350986827a1a"
-  integrity sha512-fCZ2GNpsoWyroZ/j86JUHnGWmjCMcGGNqD4ll6fepR3EFN9YGySLLJzkQiXEDGap5+vmwcURyac8MPl6jP2FsQ==
-  dependencies:
-    lodash "^4.17.10"
-    qs "^6.5.2"
-
-contentful@6.1.0:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/contentful/-/contentful-6.1.0.tgz#c8f6761a7180cfe66ef54391cf07b8f864549c0c"
-  integrity sha512-jAFw4Vk9ucOxbUIu9ZWIAwluMcK307YTDQnnhS+vCYOM4wMfmUsPhebX+c+bKGNunxiWjk6/4+RuODVwl/eJWA==
-  dependencies:
-    "@contentful/axios" "^0.18.0"
-    contentful-resolve-response "^1.1.4"
-    contentful-sdk-core "^6.0.0-beta0"
-    json-stringify-safe "^5.0.1"
-    lodash "^4.17.5"
-
 convert-css-length@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/convert-css-length/-/convert-css-length-1.0.2.tgz#32f38a8ac55d78372ff43562532564366c871ccc"
@@ -4204,7 +4170,7 @@ folktale@^2.0.1:
   resolved "https://registry.yarnpkg.com/folktale/-/folktale-2.3.2.tgz#38231b039e5ef36989920cbf805bf6b227bf4fd4"
   integrity sha512-+8GbtQBwEqutP0v3uajDDoN64K2ehmHd0cjlghhxh0WpcfPzAIjPA03e1VvHlxL02FVGR0A6lwXsNQKn3H1RNQ==
 
-follow-redirects@^1.0.0, follow-redirects@^1.2.5:
+follow-redirects@^1.0.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.7.0.tgz#489ebc198dc0e7f64167bd23b03c4c19b5784c76"
   integrity sha512-m/pZQy4Gj287eNy94nivy5wchN3Kp+Q5WgUPNy5lJSZ3sgkVKSYV/ZChMAQVIgx1SqfZ2zBZtPA2YlXIWxxJOQ==
@@ -4527,6 +4493,16 @@ gatsby-source-filesystem@^2.0.23:
     slash "^1.0.0"
     valid-url "^1.0.9"
     xstate "^3.1.0"
+
+gatsby-transformer-javascript-frontmatter@^2.0.9:
+  version "2.0.9"
+  resolved "https://registry.yarnpkg.com/gatsby-transformer-javascript-frontmatter/-/gatsby-transformer-javascript-frontmatter-2.0.9.tgz#c971d184f6095df49ecefec7ac0c48fdf88d2c13"
+  integrity sha512-q9a/q2K8J5+eFkRJ2f2b5WS5aIPzvaASY61vDh2ZuXZIIKLKTlxne8t7QzgrWZVbPoLs3Fy0IbGyEMx9LELE6g==
+  dependencies:
+    "@babel/parser" "^7.0.0"
+    "@babel/runtime" "^7.0.0"
+    "@babel/traverse" "^7.0.0"
+    bluebird "^3.5.0"
 
 gatsby-transformer-remark@^2.1.1:
   version "2.3.1"
@@ -8444,11 +8420,6 @@ qs@6.5.2, qs@~6.5.2:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
   integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
-
-qs@^6.5.2:
-  version "6.6.0"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.6.0.tgz#a99c0f69a8d26bf7ef012f871cdabb0aee4424c2"
-  integrity sha512-KIJqT9jQJDQx5h5uAVPimw6yVg2SekOKu959OCtktD3FjzbpvaPr8i4zzg07DOMz+igA4W/aNM7OV8H37pFYfA==
 
 querystring-es3@^0.2.0:
   version "0.2.1"


### PR DESCRIPTION
See issue: https://github.com/kalwalt/gatsby-starter-i18n-bulma/issues/6 and https://github.com/kalwalt/gatsby-starter-i18n-bulma/issues/7
I solve the issue #6 adding a "/" at the start of the path of every Link component, in this way gatsby is assured of internal link..
Instead for issue #7 i added the `gatsby-transformer-javascript-frontmatter` and in the blog (/en/  and /it/) index page i added:

```javascript
export const frontmatter = {
  id:  '02',
  title: "pagina blog",
}
```

in thys way that page has not an empty id anymore.