### PR TITLE
Better navbar and select language on the right

### DIFF
--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -72,9 +72,6 @@ const Header = class extends React.Component {
    return (
 
 <header>
-<div className="navbar-end has-text-centered">
-  <SelectLanguage langs={props.langs} />
-</div>
     <nav className="navbar is-transparent" role="navigation" aria-label="main-navigation">
       <div className="container">
         <div className="navbar-brand">
@@ -120,6 +117,11 @@ const Header = class extends React.Component {
           <Link className="navbar-item" to={"/" + props.langKey + "/" + menuTree.contact[sel] +"/"}>
             <FaAmericanSignLanguageInterpreting className="menu-names" /> <FormattedMessage id="contact" />
           </Link>
+        </div>
+        <div className="navbar-end">
+          <div class="navbar-item  has-text-centered">
+            <SelectLanguage langs={props.langs} />
+          </div>
         </div>
         </div>
       </div>

--- a/src/components/SelectLanguage.js
+++ b/src/components/SelectLanguage.js
@@ -25,7 +25,7 @@ const SelectLanguage = (props) => {
   );
 
   return (
-    <section className="section">
+    <div className="section" style={{ padding: '1.5rem' }}>
       <header style={{
         color: '#D64000'
       }}>
@@ -34,7 +34,7 @@ const SelectLanguage = (props) => {
       <ul>
         {links}
       </ul>
-    </section>
+    </div>
   );
 };
 


### PR DESCRIPTION
The navbar was too wide in height, i modified the SelectLanguage Component and the navbar itself. 
The SelectLanguage now is on the right on the same line of the bar, becuae is inside a `navbar-end` element. Before it was wrong, even if i added the `navbar-end` class because it was inside a div with a `navbar-start` class can't stay to the right...