### PR TITLE
Better Lightbox and other improves

### DIFF
--- a/src/components/Lightbox.js
+++ b/src/components/Lightbox.js
@@ -89,9 +89,9 @@ class Lightbox extends Component {
       <section className="section">
       {display === true ?
       <Fragment>
-        <div className="columns">
+        <div className="columns is-multiline">
           {images.map((img, i) => (
-            <div className="column" key={img.childImageSharp.fluid.src}>
+            <div className="column is-one-quarter" key={img.childImageSharp.fluid.src}>
               <a id="img-lightbox" className="image" href={img.childImageSharp.fluid.src} alt="Image" onClick={e => this.handleClick(e, i)}>
                 <Img fluid={img.childImageSharp.fluid} style={imageStyle} />
               </a>

--- a/src/components/Lightbox.js
+++ b/src/components/Lightbox.js
@@ -91,9 +91,9 @@ class Lightbox extends Component {
       <Fragment>
         <div className="columns is-multiline">
           {images.map((img, i) => (
-            <div className="column is-one-quarter" key={img.childImageSharp.fluid.src}>
-              <a id="img-lightbox" className="image" href={img.childImageSharp.fluid.src} alt="Image" onClick={e => this.handleClick(e, i)}>
-                <Img fluid={img.childImageSharp.fluid} style={imageStyle} />
+            <div className="column is-one-quarter" key={img.image.childImageSharp.fluid.src}>
+              <a id="img-lightbox" className="image" href={img.image.childImageSharp.fluid.src} alt={img.alt} onClick={e => this.handleClick(e, i)}>
+                <Img fluid={img.image.childImageSharp.fluid} alt={img.alt} style={imageStyle} />
               </a>
             </div>
           ))}
@@ -104,7 +104,7 @@ class Lightbox extends Component {
           <div className="modal-background"></div>
           <div className="modal-content">
           <button id="modal-close" className="modal-close is-large" aria-label="close"></button>
-            <Img  fluid={images[selectedImage].childImageSharp.fluid} />
+            <Img  fluid={images[selectedImage].image.childImageSharp.fluid} />
             <footer className="modal-card-foot">
                 <button className="button is-primary" onClick={this.goBack} disabled={selectedImage === 0}>
                   Previous

--- a/src/pages/artworks/new-media/aumgmented-reality.en.md
+++ b/src/pages/artworks/new-media/aumgmented-reality.en.md
@@ -22,11 +22,6 @@ intro:
 slider:
   display: 'false'
   array: []
-lightbox:
-  display: true
-  images:
-    - /img/Kaki.jpg
-    - /img/Persimmon.jpg
 testimonials:
   - author: ""
     quote: ""

--- a/src/pages/artworks/new-media/experimental.en.md
+++ b/src/pages/artworks/new-media/experimental.en.md
@@ -22,11 +22,6 @@ intro:
 slider:
   display: 'false'
   array: []
-lightbox:
-  display: true
-  images:
-    - /img/Kaki.jpg
-    - /img/Persimmon.jpg
 testimonials:
   - author: ""
     quote: ""

--- a/src/pages/artworks/painting/new/abstract-art-persimmon-among-the-stars.en.md
+++ b/src/pages/artworks/painting/new/abstract-art-persimmon-among-the-stars.en.md
@@ -16,7 +16,7 @@ lightbox:
   images:
     - image: /img/Kaki.jpg
       alt: "Some Persimmon on the tree"
-    - image: img/Persimmon.jpg
+    - image: /img/Persimmon.jpg
       alt: "A Persimmon tree"
 info:
   title: "A Persimmon among the stars"

--- a/src/pages/artworks/painting/new/abstract-art-persimmon-among-the-stars.en.md
+++ b/src/pages/artworks/painting/new/abstract-art-persimmon-among-the-stars.en.md
@@ -14,8 +14,10 @@ slug: /en/artwork/painting/new/abstract-art-persimmon-among-the-stars/
 lightbox:
   display: true
   images:
-    - /img/Kaki.jpg
-    - /img/Persimmon.jpg
+    - image: /img/Kaki.jpg
+      alt: "Some Persimmon on the tree"
+    - image: img/Persimmon.jpg
+      alt: "A Persimmon tree"
 info:
   title: "A Persimmon among the stars"
   artworkTitle: "A Persimmon among the stars"

--- a/src/pages/artworks/painting/new/index.en.md
+++ b/src/pages/artworks/painting/new/index.en.md
@@ -23,8 +23,8 @@ slider:
   display: 'false'
   array: []
 testimonials:
-  - author: ""
-    quote: ""
+  - author: "unknown"
+    quote: "A Kaki may save your life!"
 ---
 
 ## Painting

--- a/src/pages/artworks/painting/new/index.en.md
+++ b/src/pages/artworks/painting/new/index.en.md
@@ -22,11 +22,6 @@ intro:
 slider:
   display: 'false'
   array: []
-lightbox:
-  display: true
-  images:
-    - /img/Kaki.jpg
-    - /img/Persimmon.jpg
 testimonials:
   - author: ""
     quote: ""

--- a/src/pages/artworks/painting/oldest/index.en.md
+++ b/src/pages/artworks/painting/oldest/index.en.md
@@ -22,11 +22,6 @@ intro:
 slider:
   display: 'false'
   array: []
-lightbox:
-  display: true
-  images:
-    - /img/Kaki.jpg
-    - /img/Persimmon.jpg
 testimonials:
   - author: ""
     quote: ""

--- a/src/pages/artworks/performance/introduction.en.md
+++ b/src/pages/artworks/performance/introduction.en.md
@@ -22,11 +22,6 @@ intro:
 slider:
   display: 'false'
   array: []
-lightbox:
-  display: true
-  images:
-    - /img/Kaki.jpg
-    - /img/Persimmon.jpg
 testimonials:
   - author: ""
     quote: ""

--- a/src/pages/artworks/performance/performance01.en.md
+++ b/src/pages/artworks/performance/performance01.en.md
@@ -16,7 +16,7 @@ lightbox:
   images:
     - image: /img/Kaki.jpg
       alt: "Some Persimmon on the tree"
-    - image: img/Persimmon.jpg
+    - image: /img/Persimmon.jpg
       alt: "A Persimmon tree"
 info:
   title: "Un caco tra le stelle"

--- a/src/pages/artworks/performance/performance01.en.md
+++ b/src/pages/artworks/performance/performance01.en.md
@@ -11,6 +11,13 @@ lang: en
 date: "22-03-2019"
 path: /en/artworks/performance/performance01/
 slug: /en/artworks/performance/performance01/
+lightbox:
+  display: true
+  images:
+    - image: /img/Kaki.jpg
+      alt: "Some Persimmon on the tree"
+    - image: img/Persimmon.jpg
+      alt: "A Persimmon tree"
 info:
   title: "Un caco tra le stelle"
   artworkTitle: "Un caco tra le stelle"

--- a/src/pages/artworks/performance/performance01.en.md
+++ b/src/pages/artworks/performance/performance01.en.md
@@ -28,11 +28,6 @@ intro:
 slider:
   display: 'false'
   array: []
-lightbox:
-  display: true
-  images:
-    - /img/Kaki.jpg
-    - /img/Persimmon.jpg
 testimonials:
   - author: ""
     quote: ""

--- a/src/pages/artworks/performance/performance02.en.md
+++ b/src/pages/artworks/performance/performance02.en.md
@@ -16,7 +16,7 @@ lightbox:
   images:
     - image: /img/Kaki.jpg
       alt: "Some Persimmon on the tree"
-    - image: img/Persimmon.jpg
+    - image: /img/Persimmon.jpg
       alt: "A Persimmon tree"
 info:
   title: "Un caco tra le stelle"

--- a/src/pages/artworks/performance/performance02.en.md
+++ b/src/pages/artworks/performance/performance02.en.md
@@ -11,6 +11,13 @@ lang: en
 date: "22-03-2019"
 path: /en/artworks/performance/performance02/
 slug: /en/artworks/performance/performance02/
+lightbox:
+  display: true
+  images:
+    - image: /img/Kaki.jpg
+      alt: "Some Persimmon on the tree"
+    - image: img/Persimmon.jpg
+      alt: "A Persimmon tree"
 info:
   title: "Un caco tra le stelle"
   artworkTitle: "Un caco tra le stelle"

--- a/src/pages/artworks/performance/performance02.en.md
+++ b/src/pages/artworks/performance/performance02.en.md
@@ -28,11 +28,6 @@ intro:
 slider:
   display: 'false'
   array: []
-lightbox:
-  display: true
-  images:
-    - /img/Kaki.jpg
-    - /img/Persimmon.jpg
 testimonials:
   - author: ""
     quote: ""

--- a/src/pages/artworks/performance/performance03.en.md
+++ b/src/pages/artworks/performance/performance03.en.md
@@ -16,7 +16,7 @@ lightbox:
   images:
     - image: /img/Kaki.jpg
       alt: "Some Persimmon on the tree"
-    - image: img/Persimmon.jpg
+    - image: /img/Persimmon.jpg
       alt: "A Persimmon tree"
 info:
   title: "Un caco tra le stelle"

--- a/src/pages/artworks/performance/performance03.en.md
+++ b/src/pages/artworks/performance/performance03.en.md
@@ -11,6 +11,13 @@ lang: en
 date: "22-03-2019"
 path: /en/artworks/performance/performance03/
 slug: /en/artworks/performance/performance03/
+lightbox:
+  display: true
+  images:
+    - image: /img/Kaki.jpg
+      alt: "Some Persimmon on the tree"
+    - image: img/Persimmon.jpg
+      alt: "A Persimmon tree"
 info:
   title: "Un caco tra le stelle"
   artworkTitle: "Un caco tra le stelle"

--- a/src/pages/artworks/performance/performance03.en.md
+++ b/src/pages/artworks/performance/performance03.en.md
@@ -28,11 +28,6 @@ intro:
 slider:
   display: 'false'
   array: []
-lightbox:
-  display: true
-  images:
-    - /img/Kaki.jpg
-    - /img/Persimmon.jpg
 testimonials:
   - author: ""
     quote: ""

--- a/src/pages/artworks/performance/performance04.en.md
+++ b/src/pages/artworks/performance/performance04.en.md
@@ -16,7 +16,7 @@ lightbox:
   images:
     - image: /img/Kaki.jpg
       alt: "Some Persimmon on the tree"
-    - image: img/Persimmon.jpg
+    - image: /img/Persimmon.jpg
       alt: "A Persimmon tree"
 info:
   title: "Un caco tra le stelle"

--- a/src/pages/artworks/performance/performance04.en.md
+++ b/src/pages/artworks/performance/performance04.en.md
@@ -28,11 +28,6 @@ intro:
 slider:
   display: 'false'
   array: []
-lightbox:
-  display: true
-  images:
-    - /img/Kaki.jpg
-    - /img/Persimmon.jpg
 testimonials:
   - author: ""
     quote: ""

--- a/src/pages/artworks/performance/performance04.en.md
+++ b/src/pages/artworks/performance/performance04.en.md
@@ -11,6 +11,13 @@ lang: en
 date: "22-03-2019"
 path: /en/artworks/performance/performance04/
 slug: /en/artworks/performance/performance04/
+lightbox:
+  display: true
+  images:
+    - image: /img/Kaki.jpg
+      alt: "Some Persimmon on the tree"
+    - image: img/Persimmon.jpg
+      alt: "A Persimmon tree"
 info:
   title: "Un caco tra le stelle"
   artworkTitle: "Un caco tra le stelle"

--- a/src/pages/artworks/sculpture/introduction.en.md
+++ b/src/pages/artworks/sculpture/introduction.en.md
@@ -22,11 +22,6 @@ intro:
 slider:
   display: 'false'
   array: []
-lightbox:
-  display: true
-  images:
-    - /img/Kaki.jpg
-    - /img/Persimmon.jpg
 ---
 
 ## Sculpture introduction

--- a/src/pages/opere/new-media/experimental.it.md
+++ b/src/pages/opere/new-media/experimental.it.md
@@ -22,11 +22,6 @@ intro:
 slider:
   display: 'false'
   array: []
-lightbox:
-  display: true
-  images:
-    - /img/Kaki.jpg
-    - /img/Persimmon.jpg
 testimonials:
   - author: ""
     quote: ""

--- a/src/pages/opere/new-media/realtà-aumentata.it.md
+++ b/src/pages/opere/new-media/realtà-aumentata.it.md
@@ -22,11 +22,6 @@ intro:
 slider:
   display: 'false'
   array: []
-lightbox:
-  display: true
-  images:
-    - /img/Kaki.jpg
-    - /img/Persimmon.jpg
 testimonials:
   - author: ""
     quote: ""

--- a/src/pages/opere/performance/introduzione.it.md
+++ b/src/pages/opere/performance/introduzione.it.md
@@ -22,11 +22,6 @@ intro:
 slider:
   display: 'false'
   array: []
-lightbox:
-  display: true
-  images:
-    - /img/Kaki.jpg
-    - /img/Persimmon.jpg
 testimonials:
   - author: ""
     quote: ""

--- a/src/pages/opere/performance/performance01.it.md
+++ b/src/pages/opere/performance/performance01.it.md
@@ -11,6 +11,13 @@ lang: it
 date: "22-03-2019"
 path: /it/opere/performance/performance01/
 slug: /it/opere/performance/performance01/
+lightbox:
+  display: true
+  images:
+    - image: /img/Kaki.jpg
+      alt: "qualche Kako sull albero"
+    - image: /img/Persimmon.jpg
+      alt: "Un albero del Kako"
 info:
   title: "Un caco tra le stelle"
   artworkTitle: "Un caco tra le stelle"

--- a/src/pages/opere/performance/performance01.it.md
+++ b/src/pages/opere/performance/performance01.it.md
@@ -28,11 +28,6 @@ intro:
 slider:
   display: 'false'
   array: []
-lightbox:
-  display: true
-  images:
-    - /img/Kaki.jpg
-    - /img/Persimmon.jpg
 testimonials:
   - author: ""
     quote: ""

--- a/src/pages/opere/performance/performance02.it.md
+++ b/src/pages/opere/performance/performance02.it.md
@@ -28,11 +28,6 @@ intro:
 slider:
   display: 'false'
   array: []
-lightbox:
-  display: true
-  images:
-    - /img/Kaki.jpg
-    - /img/Persimmon.jpg
 testimonials:
   - author: ""
     quote: ""

--- a/src/pages/opere/performance/performance02.it.md
+++ b/src/pages/opere/performance/performance02.it.md
@@ -11,6 +11,13 @@ lang: it
 date: "22-03-2019"
 path: /it/opere/performance/performance02/
 slug: /it/opere/performance/performance02/
+lightbox:
+  display: true
+  images:
+    - image: /img/Kaki.jpg
+      alt: "qualche Kako sull albero"
+    - image: /img/Persimmon.jpg
+      alt: "Un albero del Kako"
 info:
   title: "Un caco tra le stelle"
   artworkTitle: "Un caco tra le stelle"

--- a/src/pages/opere/performance/performance03.it.md
+++ b/src/pages/opere/performance/performance03.it.md
@@ -11,6 +11,13 @@ lang: it
 date: "22-03-2019"
 path: /it/opere/performance/performance03/
 slug: /it/opere/performance/performance03/
+lightbox:
+  display: true
+  images:
+    - image: /img/Kaki.jpg
+      alt: "qualche Kako sull albero"
+    - image: /img/Persimmon.jpg
+      alt: "Un albero del Kako"
 info:
   title: "Un caco tra le stelle"
   artworkTitle: "Un caco tra le stelle"

--- a/src/pages/opere/performance/performance03.it.md
+++ b/src/pages/opere/performance/performance03.it.md
@@ -28,11 +28,6 @@ intro:
 slider:
   display: 'false'
   array: []
-lightbox:
-  display: true
-  images:
-    - /img/Kaki.jpg
-    - /img/Persimmon.jpg
 testimonials:
   - author: ""
     quote: ""

--- a/src/pages/opere/performance/performance04.it.md
+++ b/src/pages/opere/performance/performance04.it.md
@@ -11,6 +11,13 @@ lang: it
 date: "22-03-2019"
 path: /it/opere/performance/performance04/
 slug: /it/opere/performance/performance04/
+lightbox:
+  display: true
+  images:
+    - image: /img/Kaki.jpg
+      alt: "qualche Kako sull albero"
+    - image: /img/Persimmon.jpg
+      alt: "Un albero del Kako"
 info:
   title: "Un caco tra le stelle"
   artworkTitle: "Un caco tra le stelle"

--- a/src/pages/opere/performance/performance04.it.md
+++ b/src/pages/opere/performance/performance04.it.md
@@ -28,11 +28,6 @@ intro:
 slider:
   display: 'false'
   array: []
-lightbox:
-  display: true
-  images:
-    - /img/Kaki.jpg
-    - /img/Persimmon.jpg
 testimonials:
   - author: ""
     quote: ""

--- a/src/pages/opere/pittura/archivio/index.it.md
+++ b/src/pages/opere/pittura/archivio/index.it.md
@@ -22,11 +22,6 @@ intro:
 slider:
   display: 'false'
   array: []
-lightbox:
-  display: true
-  images:
-    - /img/Kaki.jpg
-    - /img/Persimmon.jpg
 testimonials:
   - author: ""
     quote: ""

--- a/src/pages/opere/pittura/nuova/arte-astratta-caco-tra-le-stelle.it.md
+++ b/src/pages/opere/pittura/nuova/arte-astratta-caco-tra-le-stelle.it.md
@@ -14,8 +14,10 @@ slug: /it/opere/pittura/nuova/arte-astratta-caco-tra-le-stelle/
 lightbox:
   display: true
   images:
-    - /img/Kaki.jpg
-    - /img/Persimmon.jpg
+    - image: /img/Kaki.jpg
+      alt: "qualche Kako sull albero"
+    - image: /img/Persimmon.jpg
+      alt: "Un albero del Kako"
 info:
   title: "Un caco tra le stelle"
   artworkTitle: "Un caco tra le stelle"

--- a/src/pages/opere/pittura/nuova/index.it.md
+++ b/src/pages/opere/pittura/nuova/index.it.md
@@ -23,8 +23,8 @@ slider:
   display: 'false'
   array: []
 testimonials:
-  - author: ""
-    quote: ""
+  - author: "sconosciuto"
+    quote: "Un kako può salvarti la vita!"
 ---
 
 ## Pittura

--- a/src/pages/opere/pittura/nuova/index.it.md
+++ b/src/pages/opere/pittura/nuova/index.it.md
@@ -22,11 +22,6 @@ intro:
 slider:
   display: 'false'
   array: []
-lightbox:
-  display: true
-  images:
-    - /img/Kaki.jpg
-    - /img/Persimmon.jpg
 testimonials:
   - author: ""
     quote: ""

--- a/src/pages/opere/scultura/introduzione.it.md
+++ b/src/pages/opere/scultura/introduzione.it.md
@@ -22,11 +22,6 @@ intro:
 slider:
   display: 'false'
   array: []
-lightbox:
-  display: true
-  images:
-    - /img/Kaki.jpg
-    - /img/Persimmon.jpg
 ---
 
 ## Scultura introduzione

--- a/src/templates/artworks-simple.js
+++ b/src/templates/artworks-simple.js
@@ -39,7 +39,7 @@ const ArtworkSimpleTemplate = ({
            </section>
          </div>
          <div className="column is-6">
-            <PageContent className="content" content={content} />
+            <PageContent className="section" content={content} />
          </div>
        </div>
     </div>

--- a/src/templates/artworks-simple.js
+++ b/src/templates/artworks-simple.js
@@ -8,7 +8,7 @@ import Content, { HTMLContent } from "../components/Content"
 import Lightbox from '../components/Lightbox'
 import InfoCard from '../components/InfoCard'
 
-const ArtworkTemplate = ({
+const ArtworkSimpleTemplate = ({
   title,
   content,
   contentComponent,
@@ -22,31 +22,31 @@ const ArtworkTemplate = ({
   const PageContent = contentComponent || Content
   return (
     <div className="content">
-   <h1 className="title animated bounceInLeft">{title}</h1>
-    <div className="hero">
-      <Lightbox lightbox={lightbox} images={images} />
-      </div>
-      <div className="section">
-        <h2 className="has-text-weight-semibold subtitle">
-        {heading}
-        </h2>
-      </div>
-      <div className="columns">
-       <div className="column is-4">
-         <section className="section">
-           <InfoCard info={info}/>
-            <TagList tags={tags} langKey={langKey}/>
-         </section>
+     <h1 className="title animated bounceInLeft">{title}</h1>
+      <div className="hero">
+        <Lightbox lightbox={lightbox} images={images} />
+        </div>
+        <div className="section">
+          <h2 className="has-text-weight-semibold subtitle">
+          {heading}
+          </h2>
+        </div>
+        <div className="columns">
+         <div className="column is-4">
+           <section className="section">
+             <InfoCard info={info}/>
+              <TagList tags={tags} langKey={langKey}/>
+           </section>
+         </div>
+         <div className="column is-6">
+            <PageContent className="content" content={content} />
+         </div>
        </div>
-       <div className="column is-6">
-          <PageContent className="content" content={content} />
-       </div>
-     </div>
-  </div>
+    </div>
     )
 }
 
-ArtworkTemplate.propTypes = {
+ArtworkSimpleTemplate.propTypes = {
   image: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
   heading: PropTypes.string,
   title: PropTypes.string.isRequired,
@@ -56,13 +56,13 @@ ArtworkTemplate.propTypes = {
     blurbs: PropTypes.array,
   }),
   array: PropTypes.array,
-  images: PropTypes.arrayOf(PropTypes.object),
+  //images: PropTypes.arrayOf(PropTypes.object),
   lightbox: PropTypes.object,
   tags: PropTypes.array,
   langKey: PropTypes.string
 }
 
-class ArtworksPage extends React.Component {
+class ArtworksSimplePage extends React.Component {
 
 render() {
   const data = this.props.data;
@@ -83,7 +83,7 @@ render() {
           postImage={image}
         />
         <div>
-            <ArtworkTemplate
+            <ArtworkSimpleTemplate
             contentComponent={HTMLContent}
             heading={frontmatter.heading}
             title={frontmatter.title}
@@ -102,7 +102,7 @@ render() {
   }
 }
 
-ArtworksPage.propTypes = {
+ArtworksSimplePage.propTypes = {
   data: PropTypes.shape({
     markdownRemark: PropTypes.shape({
       frontmatter: PropTypes.object,
@@ -110,7 +110,7 @@ ArtworksPage.propTypes = {
   }),
 }
 
-export default ArtworksPage
+export default ArtworksSimplePage
 
 export const pageQuery = graphql`
 query ArtworksSimpleQuery($id: String!) {
@@ -141,7 +141,7 @@ query ArtworksSimpleQuery($id: String!) {
        lang
        image {
          childImageSharp {
-           fluid(maxWidth: 2048, quality: 100) {
+           fluid(maxWidth: 1200, quality: 86) {
              ...GatsbyImageSharpFluid
              src
            }
@@ -181,15 +181,15 @@ query ArtworksSimpleQuery($id: String!) {
       lightbox {
         display
         images{
-         id
-         relativePath
-         childImageSharp {
-           fluid(maxWidth: 640, quality: 85) {
-             ...GatsbyImageSharpFluid
-             src
-             sizes
+          image {
+            childImageSharp {
+              fluid(maxWidth: 1200, quality: 85) {
+                ...GatsbyImageSharpFluid
+                src
+              }
             }
           }
+          alt
         }
       }
     }

--- a/src/templates/artworks-simple.js
+++ b/src/templates/artworks-simple.js
@@ -21,24 +21,28 @@ const ArtworkTemplate = ({
 }) => {
   const PageContent = contentComponent || Content
   return (
-      <div className="container content">
-       <h1 className="title animated bounceInLeft">{title}</h1>
-        <div className="hero">
-          <Lightbox lightbox={lightbox} images={images} />
-          </div>
-          <div className="columns is-multiline">
-           <div className="column is-6">
-             <h2 className="has-text-weight-semibold subtitle">
-             {heading}
-             </h2>
-             <section className="section">
-               <PageContent className="container content" content={content} />
-               <InfoCard info={info}/>
-                <TagList tags={tags} langKey={langKey}/>
-             </section>
-           </div>
-         </div>
+    <div className="content">
+   <h1 className="title animated bounceInLeft">{title}</h1>
+    <div className="hero">
+      <Lightbox lightbox={lightbox} images={images} />
       </div>
+      <div className="section">
+        <h2 className="has-text-weight-semibold subtitle">
+        {heading}
+        </h2>
+      </div>
+      <div className="columns">
+       <div className="column is-4">
+         <section className="section">
+           <InfoCard info={info}/>
+            <TagList tags={tags} langKey={langKey}/>
+         </section>
+       </div>
+       <div className="column is-6">
+          <PageContent className="content" content={content} />
+       </div>
+     </div>
+  </div>
     )
 }
 

--- a/src/templates/artworks.js
+++ b/src/templates/artworks.js
@@ -28,16 +28,16 @@ const ArtworkTemplate = ({
        <h1 className="title animated bounceInLeft">{title}</h1>
         <div className="hero">
           <Slider array={array} display={display}/>
-          </div>
-          <div className="columns">
-           <div className="column is-9">
-             <h2 className="has-text-weight-semibold subtitle">
-             {heading}
-             </h2>
-             <div className="container content">
-               {description}
-              </div>
+            <div className="section">
+              <h2 className="has-text-weight-semibold subtitle">
+              {heading}
+              </h2>
+              <div className="container content">
+                {description}
+               </div>
+             </div>
              <Features gridItems={intro.blurbs} />
+          </div>
              <div className="container content">
                <Testimonials testimonials={testimonials} />
              </div>
@@ -45,8 +45,6 @@ const ArtworkTemplate = ({
                <PageContent className="container content" content={content} />
                 <TagList tags={tags} langKey={langKey}/>
              </section>
-           </div>
-         </div>
       </div>
     )
 }

--- a/src/templates/artworks.js
+++ b/src/templates/artworks.js
@@ -180,20 +180,6 @@ query ArtworksQuery($id: String!) {
           description
         }
       }
-      lightbox {
-        display
-        images{
-         id
-         relativePath
-         childImageSharp {
-           fluid(maxWidth: 640, quality: 85) {
-             ...GatsbyImageSharpFluid
-             src
-             sizes
-            }
-          }
-        }
-      }
     }
   }
 }

--- a/src/templates/home.js
+++ b/src/templates/home.js
@@ -94,7 +94,9 @@ const HomePageTemplate = ({
        fourthLink={fourthLink}
        />
        </div>
-       <Testimonials testimonials={testimonials} />
+       <div className="section">
+          <Testimonials testimonials={testimonials} />
+       </div>
        <CardSlide
        imageInfo={imageCardSL}
        name={imageCardSL.name}


### PR DESCRIPTION
- [x] Styling improves in Lightbox Component and general improvement.
- [x] alt attribute to Lightbox Component
- [x] package upgrades

I added the alt attribute for the img in the Lightbox Component, in the frontmatter (with the `artworks-simple.js `template) you should set  the alt in this way:

```yaml
lightbox:
  display: true
  images:
    - image: /img/Kaki.jpg
      alt: "Some Persimmon on the tree"
    - image: img/Persimmon.jpg
      alt: "A Persimmon tree"
```
