### PR TITLE
reverting to v1.1.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-starter-i18n-bulma",
   "description": "Gatsby example site using i18n and bulma for CSS",
-  "version": "v1.1.3",
+  "version": "v1.1.5",
   "author": "Walter Perdan <info@kalwaltart.it> (www.kalwaltart.com)",
   "dependencies": {
     "@babel/parser": "^7.9.4",


### PR DESCRIPTION
Reverting to the latest stable version (v1.1.4). The **ContactForm** component is not sending the form data. I will try the https://github.com/jon-fm/react-ssg-netlify-forms plugin for the Form instead.