### PR TITLE
Update gatsby-config.js

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -29,7 +29,12 @@ module.exports = {
   },
   plugins: [
     `gatsby-plugin-react-helmet`,
-    'gatsby-plugin-sass',
+    {
+      resolve: 'gatsby-plugin-sass',
+      options: {
+        indentedSyntax: true
+      }
+    },
     {
       resolve: 'gatsby-plugin-i18n',
       options: {


### PR DESCRIPTION
Fix a problem compiling sass

Was getting this error when running gatsby develop, this config change fixes it
<img width="654" alt="Hyper 2021-01-18 10-59-34" src="https://user-images.githubusercontent.com/3600471/104893581-4433e300-597c-11eb-8709-e77285d5b1fe.png">

More info: https://github.com/gatsbyjs/gatsby/issues/28007
