### PR TITLE
fixes #142, separate template from component for blog-post

### DIFF
--- a/src/templates/blog-post.js
+++ b/src/templates/blog-post.js
@@ -7,7 +7,7 @@ import { graphql } from 'gatsby'
 import Layout from '../components/Layout'
 import Content, { HTMLContent } from '../components/Content'
 
-export const BlogPostTemplate = ({
+const BlogPostTemplate = ({
   data,
   location,
   content,


### PR DESCRIPTION
fixes #142 by separating out the `BlogPost` from a `BlogPostTemplate` into two separate files.

But not entirely fixed yet.  Still WIP, I think the page query may belong elsewhere or perhaps converted into a [static query](https://www.gatsbyjs.com/docs/how-to/querying-data/static-query/).

Signed-off-by: Josh Cox <josh@webhosting.coop>